### PR TITLE
[feat] Dockerize Rampart with nginx and php-fpm

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,13 @@
+version: "3.8"
+services:
+  ramp-web:
+    image: nginx:latest
+    volumes:
+      - ./nginx.conf:/etc/nginx/conf.d/default.conf
+      - .:/app/public
+    ports:
+      - 8000:80
+  php:
+    image: php:7.4-fpm
+    volumes:
+      - .:/app/public

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,12 @@
+server {
+    listen 80 default_server;
+    root /app/public;
+
+    index index.php index.html index.htm;
+
+    location ~ \.php$ {
+        fastcgi_pass php:9000;
+        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+        include fastcgi_params;
+    }
+} 


### PR DESCRIPTION
I wanted to dockerize rampart to allow for more rapid development especially from windows hosts, since with docker you wont need to install anything with PHP which means no need for all in one servers like XAMPP. 

Things to note:
* I tried to get the setup working within WSL but ran into issues with permissions, as both the docker container and the WSL container were linux we would have issues with file permissions that I dont seem to have when running the rampart container on windows instead of WSL. which means that you wont be able to run the container on linux in the same way we can with windows, as you would not be able to have instant access to files as the permissions wouldn't work well if we bridge the 2 filesystems.
* I Don't know what version of PHP is used for rampart as you specify minimum 5.6 which is pretty old so I went with 7.4 as 8.0 has a number of breaking changes for rampart.
* I have not fully tested rampart as I lack the needed items to do that as I dont have a hubmap and other maps to use to do that.