### PR TITLE
Replace split() with explode()

### DIFF
--- a/admin/handle_new_slots.php
+++ b/admin/handle_new_slots.php
@@ -36,7 +36,7 @@ for ($i = 0; $i < $slots; $i++) {
     
     //...but override them if we're using a template
     if (isset($template_entries[$i])) {
-        $template_line = split(" ", $template_entries[$i]);
+        $template_line = explode(" ", $template_entries[$i]);
         $map_lumpname = $template_line[0];
         $nextmap = $template_line[1];
         $secretnextmap = $template_line[2];

--- a/scripts/mapinfo_handler.php
+++ b/scripts/mapinfo_handler.php
@@ -19,7 +19,7 @@ class Mapinfo_Handler {
         
         //Remove anything between multi-line comments
         $this->bytes = preg_replace("/\/\*[\s\S]*\*\//", "", $this->bytes);
-        $this->mapinfo_lines = split(PHP_EOL, $this->bytes);
+        $this->mapinfo_lines = explode(PHP_EOL, $this->bytes);
         
         while ($this->current_line_number < count($this->mapinfo_lines)) {
             $line = trim($this->mapinfo_lines[$this->current_line_number]);
@@ -43,7 +43,7 @@ class Mapinfo_Handler {
                 $parsed_data['jumpcrouch'] = 1;
             }
             
-            $line_tokens = split("=", $line);
+            $line_tokens = explode("=", $line);
 
             $key = $this->clean_token($line_tokens[0]);
             if (in_array($key, ALLOWED_MAPINFO_PROPERTIES) || $key == 'music') {
@@ -85,7 +85,7 @@ class Mapinfo_Handler {
         $line = "";
         while ($line != "}" && $this->current_line_number < count($this->mapinfo_lines)) {
             $line = trim($this->mapinfo_lines[$this->current_line_number]);
-            $line_tokens = split("=", $line);
+            $line_tokens = explode("=", $line);
             if (count($line_tokens) < 2) {
                 //Doesn't have two tokens around equals? Forget it
                 $this->current_line_number++;
@@ -110,7 +110,7 @@ class Mapinfo_Handler {
         $line = "";
         while ($line != "}" && $this->current_line_number < count($this->mapinfo_lines)) {
             $line = trim($this->mapinfo_lines[$this->current_line_number]);
-            $line_tokens = split("=", $line);
+            $line_tokens = explode("=", $line);
             if (count($line_tokens) < 2) {
                 //Doesn't have two tokens around equals? Forget it
                 $this->current_line_number++;
@@ -138,4 +138,3 @@ class Mapinfo_Handler {
     }
     
 }
-

--- a/scripts/project_compiler.php
+++ b/scripts/project_compiler.php
@@ -362,7 +362,7 @@ class Project_Compiler {
                 //MODELDEF files must go in the root directory of the pk3           
                 $data_path = PK3_FOLDER . DIRECTORY_SEPARATOR . $lump['name'] . "." . $map_data['map_number'] . "-" . $number_of_modeldefs;
 
-                $modeldef_lines = split(PHP_EOL, $lump['data']);
+                $modeldef_lines = explode(PHP_EOL, $lump['data']);
 
                 $modeldef_data = "";
 

--- a/scripts/sndinfo_handler.php
+++ b/scripts/sndinfo_handler.php
@@ -10,7 +10,7 @@ class Sndinfo_Handler {
     private $requested_sound_definitions = [];
     
     public function __construct($bytes) {
-        $this->input_lines = split(PHP_EOL, $bytes);
+        $this->input_lines = explode(PHP_EOL, $bytes);
     }
     
     public function parse() {


### PR DESCRIPTION
This allows RAMPART to function correctly on more recent PHP versions (confirmed on 8.2).

`explode()` is identical to `split()` in every way. `split()` is a now-deprecated alias.