### PR TITLE
Reject lockdefs lumps that overwrite vanilla locks

### DIFF
--- a/_constants.php
+++ b/_constants.php
@@ -178,6 +178,7 @@ const COMPILE_ERRORS = [
     'ERR_LUMP_NEEDS_CONVERTED' => '$1 lumps are unsupported - convert to $2 with SLADE3',
     'ERR_LUMP_COLORMAP_UNSUPPORTED' => 'Found colormap-related lump $1, but colormaps are not supported',
     'ERR_LUMP_LOCKDEFS_CLEARLOCKS' => 'Found LOCKDEFS lump but refusing it as it performs CLEARLOCKS!',
+    'ERR_LUMP_LOCKDEFS_CONFLICTS' => 'Found LOCKDEFS lump but refusing it as it overwrites vanilla locks',
     
     'ERR_SOUND_SNDINFO_REDEFINITION' => 'SNDINFO tries to define the sound $1 as $2, but it\'s already defined as $3',
     'WARN_SOUND_SNDINFO_REDEFINITION' => 'SNDINFO defines the sound $1, which is already defined but it matches the existing definition $2',

--- a/errors.php
+++ b/errors.php
@@ -60,7 +60,8 @@ require_once($_SERVER['DOCUMENT_ROOT'] . DIRECTORY_SEPARATOR . 'header.php');
 <h4><?=get_error_link('ERR_LUMP_LOCKDEFS_CLEARLOCKS')?></h4>
 <p>Your WAD contains a LOCKDEF that uses the clearlocks command, which would erase all other previously defined locks. Reupload your WAD without using this command.</p>
 
-
+<h4><?=get_error_link('ERR_LUMP_LOCKDEFS_CONFLICTS')?></h4>
+<p>Your WAD contains a LOCKDEF that overwrites vanilla doom locks, which would change them in all maps. Change the lock numbers, preferably around <code>your map number * 100</code> and reupload your WAD</p>
 
 <h3>Sound errors</h3>
 

--- a/scripts/project_compiler.php
+++ b/scripts/project_compiler.php
@@ -375,6 +375,18 @@ class Project_Compiler {
                     continue;
                 }
                 
+                // Reject lockdefs that contain at least 1 lock that overwrites a vanilla lock
+                if ($lump['name'] == 'LOCKDEFS') {
+                    $lumptxt = $lump['data'];
+                    $lumprgx = "/^lock\s+([0-6]|10[0-1]|129|13[0-4]|229)\s*\{/mi";
+                    preg_match_all($lumprgx, $lumptxt, $matches, PREG_SET_ORDER, 0);
+                    
+                    if (preg_match($lumprgx, $lumptxt)) {
+                        Logger::pg(get_error_link('ERR_LUMP_LOCKDEFS_CONFLICTS'), $map_data['map_number'], true);
+                        continue;
+                    }
+                }
+                
                 //Another special case - reject TEXTURES if it redefines any existent lumps
                 if ($lump['name'] == 'TEXTURES') {
                     $texture_validation_result = $this->lump_guardian->validate_textures($lump['data'], $map_data['map_number']);

--- a/scripts/project_compiler.php
+++ b/scripts/project_compiler.php
@@ -371,7 +371,7 @@ class Project_Compiler {
                 
                 //Special case - reject LOCKDEFS if it tries to clear locks
                 if ($lump['name'] == 'LOCKDEFS' && strpos(strtolower($lump['data']), 'clearlocks') !== false) {
-                    Logger::pg("❌ Found " . $lump['name'] . " lump but refusing it as it performs CLEARLOCKS!", $map_data['map_number'], true);
+                    Logger::pg(get_error_link('ERR_LUMP_LOCKDEFS_CLEARLOCKS'), $map_data['map_number'], true);
                     continue;
                 }
                 


### PR DESCRIPTION
This mr prevents map submitters from overwriting locks that are included in the base doom game, the full list of lock numbers blocked is 0-6, 100-101, 129-134, and 229. This mr does __not__ prevent default keys from hexen, heretic, or strife from being overwritten should rampart ever extend to those territories.
I tried to replicate your (David's) writing style with the error messages and based them on the other error messages included in the project. But feel free to make an edit to this mr if you feel that they are unsatisfactory.
I did test this mr with 1 wad and it performed quite well, I also tested the regex with [regex101](https://regex101.com) to make sure it worked and to check it's speed and on regex101 it takes about 700μs to find a match on the first line. Which for 300 custom locks would take an estimated 0.21 seconds in total although the timing will likely be different in php.