### PR TITLE
Basic support for compressed lumps

### DIFF
--- a/scripts/project_compiler.php
+++ b/scripts/project_compiler.php
@@ -205,6 +205,10 @@ class Project_Compiler {
             if (in_array($lump['name'], ['C_START', 'C_END'])) {
                 Logger::pg("❌ " . $lump['name'] . ": Colormaps are unsupported", $map_number, true);
             }
+            
+            if ($lump['load_error']) {
+                Logger::pg("❌ " . $lump['name'] . ": failed to load", $map_number, true);
+            }
         }
     }
     

--- a/scripts/wad_handler.php
+++ b/scripts/wad_handler.php
@@ -64,7 +64,7 @@ class Wad_Handler {
         if ($lump['compressed']) {
             // The length of a compressed lump is implicit based on
             // the next entry's position, or the end of the wad.
-            if ($i + 1 > count($lumps)) {
+            if ($i + 1 >= count($lumps)) {
                 $size = $wadSize - $lump['position'];
             } else {
                 $size = $lumps[$lumpIdx + 1]['position'] - $lump['position'];


### PR DESCRIPTION
(G)ZDoom supports lumps compressed with a variant of LZSS compression by setting the high bit of the lump name to denote compressed ones.

* Adds basic support for these compressed lumps.
* Decompresses lumps before inspecting them or copying them elsewhere in the PK3.
* Compressed lumps are denoted with an asterisk next to their decompressed size in the WAD directory.