### PR TITLE
Allow noambientocclusion map property in MAPINFO

### DIFF
--- a/_constants.php
+++ b/_constants.php
@@ -61,7 +61,8 @@ $setting_defaults = [
         'specialaction_opendoor',
         'specialaction_lowerfloor',
         'specialaction_killmonsters',
-        'useplayerstartz'
+        'useplayerstartz',
+        'noambientocclusion'
     ],
 
     "GENERATE_MARQUEES" => false,


### PR DESCRIPTION
Not sure if the current release version of UZDoom supports this property yet, but since my change there was merged I'm adding it to the allow-list here.